### PR TITLE
Cron fails if directory doesn't Exists

### DIFF
--- a/Cron/GenerateSitemap.php
+++ b/Cron/GenerateSitemap.php
@@ -66,6 +66,11 @@ class GenerateSitemap
         $domain = $this->configuration->getVueStorefrontUrl();
         $path = $this->getPubPath();
 
+        // Create directory at Path if doesn't exists
+        if (!file_exists($path)) {
+            mkdir($path, 0777, true);
+        }
+        
         // Sitemap configuration
         $this->sitemap = $this->sitemapFactory->create($domain);
         $this->sitemap->setPath($path);

--- a/Cron/GenerateSitemap.php
+++ b/Cron/GenerateSitemap.php
@@ -16,6 +16,8 @@ use Vendic\VueStorefrontSitemap\Model\CategoryCollection;
 use Vendic\VueStorefrontSitemap\Model\Configuration;
 use Vendic\VueStorefrontSitemap\Model\ProductCollection;
 use Vendic\VueStorefrontSitemap\Model\SitemapFactory;
+use Magento\Framework\Filesystem\Driver\File;
+use Magento\Framework\Filesystem\Io\File as Io;
 
 class GenerateSitemap
 {
@@ -45,19 +47,32 @@ class GenerateSitemap
      * @var CategoryCollection
      */
     protected $categoryCollection;
+    /**
+     * @var File
+     */
+    protected $fileDriver;
+    /**
+     * @var Io
+     */
+    protected $io;
 
     public function __construct(
         CategoryCollection $categoryCollection,
         Configuration $configuration,
         ProductCollection $productCollection,
         DirectoryList $directoryList,
-        SitemapFactory $sitemapFactory
+        SitemapFactory $sitemapFactory,
+        File $fileDriver,
+        Io $io
     ) {
         $this->directoryList = $directoryList;
         $this->sitemapFactory = $sitemapFactory;
         $this->productCollection = $productCollection;
         $this->configuration = $configuration;
         $this->categoryCollection = $categoryCollection;
+        $this->fileDriver = $fileDriver;
+        $this->io = $io;
+        
     }
 
     public function execute() : void
@@ -67,9 +82,7 @@ class GenerateSitemap
         $path = $this->getPubPath();
 
         // Create directory at Path if doesn't exists
-        if (!file_exists($path)) {
-            mkdir($path, 0777, true);
-        }
+        if (!$this->fileDriver->isExists($path)) $this->io->mkdir($path, 0775);
         
         // Sitemap configuration
         $this->sitemap = $this->sitemapFactory->create($domain);

--- a/Cron/GenerateSitemap.php
+++ b/Cron/GenerateSitemap.php
@@ -17,7 +17,6 @@ use Vendic\VueStorefrontSitemap\Model\Configuration;
 use Vendic\VueStorefrontSitemap\Model\ProductCollection;
 use Vendic\VueStorefrontSitemap\Model\SitemapFactory;
 use Magento\Framework\Filesystem\Driver\File;
-use Magento\Framework\Filesystem\Io\File as Io;
 
 class GenerateSitemap
 {
@@ -51,10 +50,6 @@ class GenerateSitemap
      * @var File
      */
     protected $fileDriver;
-    /**
-     * @var Io
-     */
-    protected $io;
 
     public function __construct(
         CategoryCollection $categoryCollection,
@@ -62,17 +57,14 @@ class GenerateSitemap
         ProductCollection $productCollection,
         DirectoryList $directoryList,
         SitemapFactory $sitemapFactory,
-        File $fileDriver,
-        Io $io
+        File $fileDriver
     ) {
         $this->directoryList = $directoryList;
         $this->sitemapFactory = $sitemapFactory;
         $this->productCollection = $productCollection;
         $this->configuration = $configuration;
         $this->categoryCollection = $categoryCollection;
-        $this->fileDriver = $fileDriver;
-        $this->io = $io;
-        
+        $this->fileDriver = $fileDriver;        
     }
 
     public function execute() : void
@@ -82,7 +74,7 @@ class GenerateSitemap
         $path = $this->getPubPath();
 
         // Create directory at Path if doesn't exists
-        if (!$this->fileDriver->isExists($path)) $this->io->mkdir($path, 0775);
+        if (!$this->fileDriver->isDirectory($path)) $this->fileDriver->createDirectory($path, 0775);
         
         // Sitemap configuration
         $this->sitemap = $this->sitemapFactory->create($domain);


### PR DESCRIPTION
my cron failed to create `sitemap.xml` file because the directory I specified doesn't exist.

`Warning: XMLWriter::openUri(): Unable to resolve file path in /domains/admin.bedfactorydirect.co.uk/http/vendor/evert/sitemap-php/src/SitemapPHP/Sitemap.php on line 165`

by the above code changes the directory will be created programmatically.