### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "phpunit/phpunit": "^6.0"
   },
   "type": "magento2-module",
-  "version": "0.4.0",
   "license": "MIT",
   "autoload": {
     "files": [


### PR DESCRIPTION
The version can be removed from the composer.json, packagist will use the git tag to match the version. This minifies the possibilities of mistakes (new tag with old, mismatching version).